### PR TITLE
Fixed uppercase case in namespace selection

### DIFF
--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -40,7 +40,6 @@ class ShellCommands(Help):
 
         if "/" in arg and arg.split("/")[0].lower() in self.modules.keys():
             self.namespace = arg.split("/")[0].lower()
-            print(self.namespace)
             arg = arg.split("/")[1]
 
         def select_module_msg(module):

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -38,8 +38,9 @@ class ShellCommands(Help):
     def do_use(self, arg):
         """Use hardening module"""
 
-        if "/" in arg and arg.split("/")[0] in self.modules.keys():
-            self.namespace = arg.split("/")[0]
+        if "/" in arg and arg.split("/")[0].lower() in self.modules.keys():
+            self.namespace = arg.split("/")[0].lower()
+            print(self.namespace)
             arg = arg.split("/")[1]
 
         def select_module_msg(module):

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -18,7 +18,7 @@ class ShellCommands(Help):
         """Switch between modules or namespaces"""
 
         if arg:
-            if arg in self.modules.keys():
+            if arg.lower() in self.modules.keys():
                 logger.info(f"Switched to \"{arg}\" namespace." +
                             " Use 'list' to see available modules.")
                 self.namespace = arg

--- a/core/cli/commands.py
+++ b/core/cli/commands.py
@@ -18,7 +18,8 @@ class ShellCommands(Help):
         """Switch between modules or namespaces"""
 
         if arg:
-            if arg.lower() in self.modules.keys():
+            arg = arg.lower()
+            if arg in self.modules.keys():
                 logger.info(f"Switched to \"{arg}\" namespace." +
                             " Use 'list' to see available modules.")
                 self.namespace = arg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some problems with letter sensitivity have been fixed.

For example:

```
[gX]> switch KERNEL

19:41:18 > core.cli.commands > INFO > Switched to "kernel" namespace. Use 'list' to see available modules.

[gX:kernel]> back

[gX]> use KERNEL/Logs_Restrict_Access

19:41:55 > core.cli.commands > INFO > "Logs_Restrict_Access" module selected. Use 'harden' command for hardening or use 'info' for more information.

[gX:kernel:Logs_Restrict_Access]> 
```

## Motivation and Context
This change was needed to be more user-oriented and flexible.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
tested on linux
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
