### PR TITLE
Web Interface & Argparser

### DIFF
--- a/core/utils/argparser.py
+++ b/core/utils/argparser.py
@@ -17,7 +17,7 @@ def parse_cli_args():
                         '--web',
                         help='run grapheneX web server',
                         action="store_true")
-    parser.add_argument('host_port',metavar='host:port',type=str,nargs='?',default='0.0.0.0:8000',
+    parser.add_argument('host_port',metavar='host:port',type=str,nargs='?',default='0.0.0.0:8080',
                         help="host and port to run the web interface")
     args = vars(parser.parse_args())
     return args

--- a/core/utils/argparser.py
+++ b/core/utils/argparser.py
@@ -17,5 +17,7 @@ def parse_cli_args():
                         '--web',
                         help='run grapheneX web server',
                         action="store_true")
+    parser.add_argument('host_port',metavar='host:port',type=str,nargs='?',default='0.0.0.0:8000',
+                        help="host and port to run the web interface")
     args = vars(parser.parse_args())
     return args

--- a/core/utils/helpers.py
+++ b/core/utils/helpers.py
@@ -100,6 +100,6 @@ def parser_host_port(host_port):
     try:
         host, port = host_port.split(':')
     except:
-        host = host_port.split(':')[0]
+        host = host_port
         port = 8080
     return host, port

--- a/core/utils/helpers.py
+++ b/core/utils/helpers.py
@@ -103,3 +103,18 @@ def parser_host_port(host_port):
         host = host_port
         port = 8080
     return host, port
+
+def run_shell(shell):
+    try:
+        shell.cmdloop()
+    except KeyboardInterrupt:
+        shell.do_EOF(None)
+
+def run_server(app,host,port):
+    try:
+        logger.info(f'Starting Server {host}:{port}')
+        app.run(host=host,port=port)
+    except:
+        logger.error(f'Invalid host & port info')
+        logger.info(f'Using default 0.0.0.0:8080')
+        app.run('0.0.0.0',8080)

--- a/core/utils/helpers.py
+++ b/core/utils/helpers.py
@@ -96,5 +96,10 @@ def get_modules():
         modules[module_name].pop('HardenMethod')
     return modules
 
-
-        
+def parser_host_port(host_port):
+    try:
+        host, port = host_port.split(':')
+    except:
+        host = host_port.split(':')[0]
+        port = 8080
+    return host, port

--- a/core/utils/helpers.py
+++ b/core/utils/helpers.py
@@ -103,18 +103,3 @@ def parser_host_port(host_port):
         host = host_port
         port = 8080
     return host, port
-
-def run_shell(shell):
-    try:
-        shell.cmdloop()
-    except KeyboardInterrupt:
-        shell.do_EOF(None)
-
-def run_server(app,host,port):
-    try:
-        logger.info(f'Starting Server {host}:{port}')
-        app.run(host=host,port=port)
-    except:
-        logger.error(f'Invalid host & port info')
-        logger.info(f'Using default 0.0.0.0:8080')
-        app.run('0.0.0.0',8080)

--- a/grapheneX.py
+++ b/grapheneX.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from core.utils.argparser import parse_cli_args
-from core.utils.helpers import print_header, check_privileges, check_host_port,logger
+from core.utils.helpers import print_header, check_privileges, parser_host_port,logger
 from core.cli.shell import Shell
 from core.web.server import *
 

--- a/grapheneX.py
+++ b/grapheneX.py
@@ -2,18 +2,28 @@
 # -*- coding: utf-8 -*-
 
 from core.utils.argparser import parse_cli_args
-from core.utils.helpers import print_header, check_privileges
+from core.utils.helpers import print_header, check_privileges, check_host_port,logger
 from core.cli.shell import Shell
+from core.web.server import *
 
 def main():
-    parse_cli_args()
-    print_header()
-    check_privileges()
-    shell = Shell()
-    try:
-        shell.cmdloop()
-    except KeyboardInterrupt:
-        shell.do_EOF(None)
+    args = parse_cli_args()
+    if(args['web']):
+        host, port = parser_host_port(args['host_port'])
+        try:
+            app.run(host=host, port=port)
+        except:
+            logger.error("Invalid Host & Port info")
+            logger.info('Using default (host:0.0.0.0, port:8080)')
+            app.run(host='0.0.0.0', port='8080')
+    else:
+    	print_header()
+    	check_privileges()
+    	shell = Shell()
+    	try:
+    		shell.cmdloop()
+    	except KeyboardInterrupt:
+    		shell.do_EOF(None)
 
 if __name__ == "__main__":
     main()

--- a/grapheneX.py
+++ b/grapheneX.py
@@ -2,25 +2,30 @@
 # -*- coding: utf-8 -*-
 
 from core.utils.argparser import parse_cli_args
-from core.utils.helpers import print_header, check_privileges, parser_host_port, run_shell, run_server
+from core.utils.helpers import print_header, check_privileges, parser_host_port, logger
 from core.cli.shell import Shell
 from core.web.server import *
-import threading
 
 def main():
     args = parse_cli_args()
     print_header()
     check_privileges()
-    shell = Shell()
     if(args['web']):
         host, port = parser_host_port(args['host_port'])
-        shell_thread = threading.Thread(target=run_shell,args=(shell,))
-        web_thread = threading.Thread(target=run_server, args=(app,host,port))
-        shell_thread.start()
-        web_thread.start()
+        try:
+            logger.info(f'Starting Server {host}:{port}')
+            app.run(host=host, port=port)
+        except:
+            logger.error('Invalid host & port address')
+            logger.info('Using default (host: 0.0.0.0, port: 8080)')
+            logger.info('Starting Server 0.0.0.0:8080')
+            app.run(host='0.0.0.0', port=8080)
     else:
-        run_shell(shell)
-
+        shell = Shell()
+        try:
+            shell.cmdloop()
+        except KeyboardInterrupt:
+            shell.do_EOF(None)
 
 if __name__ == "__main__":
     main()

--- a/grapheneX.py
+++ b/grapheneX.py
@@ -2,28 +2,25 @@
 # -*- coding: utf-8 -*-
 
 from core.utils.argparser import parse_cli_args
-from core.utils.helpers import print_header, check_privileges, parser_host_port,logger
+from core.utils.helpers import print_header, check_privileges, parser_host_port, run_shell, run_server
 from core.cli.shell import Shell
 from core.web.server import *
+import threading
 
 def main():
     args = parse_cli_args()
+    print_header()
+    check_privileges()
+    shell = Shell()
     if(args['web']):
         host, port = parser_host_port(args['host_port'])
-        try:
-            app.run(host=host, port=port)
-        except:
-            logger.error("Invalid Host & Port info")
-            logger.info('Using default (host:0.0.0.0, port:8080)')
-            app.run(host='0.0.0.0', port='8080')
+        shell_thread = threading.Thread(target=run_shell,args=(shell,))
+        web_thread = threading.Thread(target=run_server, args=(app,host,port))
+        shell_thread.start()
+        web_thread.start()
     else:
-    	print_header()
-    	check_privileges()
-    	shell = Shell()
-    	try:
-    		shell.cmdloop()
-    	except KeyboardInterrupt:
-    		shell.do_EOF(None)
+        run_shell(shell)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the -w argument is entered, the web server will be executed with the given host and port parameters or default values

## Motivation and Context
To start the web server, the -w argument had to be captured.
The optional host and port address needed to be specified if the user wanted to work on a different host or port.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on Windows 10 and Arch Linux
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/36725317/57414042-34ec2080-71ff-11e9-9e33-ee10b225c181.png)

![image](https://user-images.githubusercontent.com/36725317/57414090-711f8100-71ff-11e9-83b3-8372f6b804ca.png)

![image](https://user-images.githubusercontent.com/36725317/57414153-a330e300-71ff-11e9-8ad9-81e951a3146e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
