### PR TITLE
Add SSH password login disable module

### DIFF
--- a/graphenex/modules.json
+++ b/graphenex/modules.json
@@ -389,6 +389,13 @@
             "command": "echo \"PermitRootLogin no\" >> /etc/ssh/ssh_config",
             "require_superuser": "True",
             "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Password_Login",
+            "desc": "Disable SSH authentication using passwords and forces keys instead",
+            "command": "echo \"ChallengeResponseAuthentication no\" >> /etc/ssh/sshd_config && echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "target_os": "linux"
         }
     ],
     "presets": [

--- a/graphenex/modules.json
+++ b/graphenex/modules.json
@@ -392,7 +392,7 @@
         },
         {
             "name": "SSH_Disable_Password_Login",
-            "desc": "Disable SSH authentication using passwords and forces keys instead",
+            "desc": "Disable SSH authentication using passwords and force keys instead",
             "command": "echo \"ChallengeResponseAuthentication no\" >> /etc/ssh/sshd_config && echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
             "require_superuser": "True",
             "target_os": "linux"


### PR DESCRIPTION
This adds a new SSH hardening module.

## Description
It's generally advised to disable password login on SSH because password security is often insufficient and keys are many times more secure. This module disables password login for all users and forces public key authentication.

## How Has This Been Tested?
Tested on my main VPS and a small testing server. No issues.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
