### PR TITLE
fix: edit hardening modules

### DIFF
--- a/graphenex/core/hrd/exec.py
+++ b/graphenex/core/hrd/exec.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3.10
 
+import os
 import shlex
 import subprocess
 from abc import ABC, abstractmethod
@@ -17,7 +18,8 @@ class LinuxExec(OsExec):
         Executes the Linux command and returns it's output in UTF-8 format.
         Supports passing `kwargs`.
         """
-        
+
+        cmd = cmd.replace("$USER", os.environ["USER"])
         args = shlex.split(cmd)
         out = subprocess.PIPE
         if args[-2] == '>' or args[-2] == '>>':

--- a/graphenex/core/web/views.py
+++ b/graphenex/core/web/views.py
@@ -93,7 +93,7 @@ def get_current_namespace(data):
     """Set the current namespace and send modules"""
     modules = list()
     mod_dict = module_dict.get(data)
-    if mod_dict == None:
+    if mod_dict is None:
         logger.warn(f"Non-existent namespace: \"{data}\".")
     else:
         global current_namespace
@@ -145,9 +145,9 @@ def hardening_exec(data):
     except PermissionError:
         err_msg = "Insufficient permissions for hardening."
         if check_os():
-            err_msg += " Get admin rights and rerun the grapheneX."
+            err_msg += " Get admin rights and rerun grapheneX."
         else:
-            err_msg += " Try running the grapheneX with sudo."
+            err_msg += " Try running grapheneX with sudo."
         emit('log_message', {
             'tag': 'warning',
             'content': err_msg,

--- a/graphenex/modules.json
+++ b/graphenex/modules.json
@@ -225,28 +225,28 @@
       "name": "Force_SYN",
       "desc": "Make sure new incoming TCP connections are SYN packets",
       "command": "iptables -A INPUT -p tcp ! --syn -m state --state NEW -j DROP",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "Fragment_Drop",
       "desc": "Drop the incoming packets with fragments",
       "command": "iptables -A INPUT -f -j DROP",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "XMAS_Drop",
       "desc": "Drop the incoming malformed XMAS packets",
       "command": "iptables -A INPUT -p tcp --tcp-flags ALL ALL -j DROP",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "Drop_Null",
       "desc": "Drop the incoming malformed NULL packets",
       "command": "iptables -A INPUT -p tcp --tcp-flags ALL NONE -j DROP",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
@@ -355,28 +355,28 @@
       "name": "Logs_Restrict_Access",
       "desc": "Restrict access to kernel logs",
       "command": "echo \"kernel.dmesg_restrict = 1\" > /etc/sysctl.d/50-dmesg-restrict.conf",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "Pointers_Restrict_Access",
       "desc": "Restrict access to kernel pointers",
       "command": "echo \"kernel.kptr_restrict = 1\" > /etc/sysctl.d/50-kptr-restrict.conf",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "ExecShield_Protection",
       "desc": "Enable the ExecShield protection",
       "command": "echo \"kernel.exec-shield = 2\" > /etc/sysctl.d/50-exec-shield.conf",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     },
     {
       "name": "Randomise_Memory",
       "desc": "Randomise the memory space",
       "command": "echo \"kernel.randomize_va_space=2\" > /etc/sysctl.d/50-rand-va-space.conf",
-      "require_superuser": "False",
+      "require_superuser": "True",
       "target_os": "linux"
     }
   ],
@@ -469,7 +469,7 @@
     },
     {
       "name": "SSH_Login_Grace_Time",
-      "desc": "Reduce the amout of time (in seconds) a user has to complete authentication after connecting to SSH server",
+      "desc": "Reduce the amount of time (in seconds) a user has to complete authentication after connecting to SSH server",
       "command": "echo \"LoginGraceTime 30\" >> /etc/ssh/sshd_config",
       "require_superuser": "True",
       "target_os": "linux"


### PR DESCRIPTION
- changed require_super user for some modules (I tested execution of every single  linux command on brand new virtual machine, and changed require_superuser accordingly to results)
- fix "amout" typo in modules.json
- check for "is None" in views.py, which is faster than "== None"
- check if $USER env variable is present in cmd, and replace it with os.environ["USER"] to fix user/Set_Home_Dir_Permission chmod error

It would also be good if we could use the "require_superuser" when executing hardening modules, because as of right now (at least in Web UI) we are catching PermissionError which works great for some modules, but it doesn't catch others (#136).
