### PR TITLE
fix: Use shell for running commands on Linux

### DIFF
--- a/graphenex/core/hrd/exec.py
+++ b/graphenex/core/hrd/exec.py
@@ -6,24 +6,22 @@ from abc import ABC, abstractmethod
 
 class OsExec(ABC):
     @abstractmethod
-    def run_cmd(self):
+    def run_cmd(self, cmd):
         pass
 
 
 class LinuxExec(OsExec):
-    def run_cmd(self, cmd, **kwargs):
+    def run_cmd(self, cmd, shell=True, **kwargs):
         """
         Executes the Linux command and returns it's output in UTF-8 format.
         Supports passing `kwargs`.
         """
 
         cmd = cmd.replace("$USER", os.environ["USER"])
-        args = shlex.split(cmd)
-        out = subprocess.PIPE
-        if args[-2] == '>' or args[-2] == '>>':
-            out = open(args[-1], 'w' if args[-2] == '>' else 'a')
-            args = args[:-2]
-        result = subprocess.run(args, stdout=out, **kwargs)
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, shell=shell, **kwargs)
+        if result.returncode != 0:
+            raise PermissionError
+
         try:
             return result.stdout.decode('utf-8')
         except AttributeError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- no longer need shlex to split commands in LinuxExec as we have added shell=True.
- no longer need to check for the mode of file since shell=True will interpret "&&" as shell chaining in multi command.
- If the return code is not 0 we 100% know that the command has failed, therefore we raise PermissionError, which is than caught in the Web UI.

closes #136
closes #143 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
