### PR TITLE
chore: Bump the Python version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as python
+FROM python:3.10-slim as python
 LABEL maintainer="graphenex.project@protonmail.com"
 ENV LC_ALL=C.UTF-8
 ENV PYTHONUNBUFFERED=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While building the docker image from the dockerfile, poetry throws a `NoCompatiblePythonVersionFound` error at the line 15 of the dockerfile `RUN poetry install --no-interaction --no-ansi -vvv`. Poetry requires python version > 3.10 as inferred from the docker build error message.
Changing the base image to **python:3.10-slim** solves the problem.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change will fix the docker build process.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By successfully building the docker image.
## Screenshots (if appropriate):
Previous error:
![image](https://github.com/grapheneX/grapheneX/assets/98466550/15583333-8c5b-4e21-94c7-7c9a18616e31)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
