### PR TITLE
feat: Add require restart

### DIFF
--- a/graphenex/core/cli/commands.py
+++ b/graphenex/core/cli/commands.py
@@ -447,7 +447,7 @@ class ShellCommands(Help):
         else:
             try:
                 hrd = self.modules[self.namespace][self.module]
-                out = hrd.execute_command()
+                hrd.execute_command()
                 logger.info("Hardening command executed successfully.")
             except PermissionError:
                 err_msg = "Insufficient permissions for hardening."

--- a/graphenex/core/cli/commands.py
+++ b/graphenex/core/cli/commands.py
@@ -220,7 +220,12 @@ class ShellCommands(Help):
                     {
                         'type': 'confirm',
                         'name': 'mod_su',
-                        'message': 'Does this command requires superuser?',
+                        'message': 'Does this command require superuser?',
+                    },
+                    {
+                        'type': 'confirm',
+                        'name': 'mod_rr',
+                        'message': 'Does this command require OS / Service restart?'
                     }
                 ]
                 if mod_ns == "new":
@@ -233,18 +238,24 @@ class ShellCommands(Help):
                     mod_namespace = prompt(mod_question)
                 try:
                     mod_ns = mod_namespace['mod_ns']
-                except KeyError:
+                except Exception:
                     pass
                 # Assigning property to the ModuleNameValidation class to
                 # access modules within the selected namespace.
                 ModuleNameValidation.modules = self.modules[mod_ns].keys() \
                     if mod_ns in self.modules.keys() else []
                 mod_details = prompt(mod_questions)
+
+                # Convert boolean values to strings
+                require_superuser_str = "True" if mod_details['mod_su'] else "False"
+                require_restart_str = "True" if mod_details['mod_rr'] else "False"
+
                 mod_dict = {
                     "name": mod_details['mod_name'].title(),
                     "desc": mod_details['mod_desc'],
                     "command": mod_details['mod_cmd'],
-                    "require_superuser": mod_details['mod_su'],
+                    "require_superuser": require_superuser_str,
+                    "require_restart": require_restart_str,
                     "target_os": "win" if check_os() else "linux"
                 }
                 try:

--- a/graphenex/core/cli/commands.py
+++ b/graphenex/core/cli/commands.py
@@ -431,13 +431,23 @@ class ShellCommands(Help):
     def do_harden(self, arg):
         """Execute the hardening command"""
 
+        namespace_data = get_mod_json()[self.namespace]
+        mod_requires_restart = None
+
+        for module in namespace_data:
+            if module["name"] == self.module:
+                mod_requires_restart = module["require_restart"]
+                break
+
+        if mod_requires_restart:
+            logger.info(f"{self.module} requires restart of OS or the service itself for the changes to apply.")
+
         if not (self.module and self.namespace):
             logger.error('Select a module/namespace.')
         else:
             try:
                 hrd = self.modules[self.namespace][self.module]
                 out = hrd.execute_command()
-                print(out)
                 logger.info("Hardening command executed successfully.")
             except PermissionError:
                 err_msg = "Insufficient permissions for hardening."

--- a/graphenex/core/web/static/js/index.js
+++ b/graphenex/core/web/static/js/index.js
@@ -85,7 +85,8 @@ saveModal = () => {
         "name": $("#amod_name").val(),
         "desc": $("#amod_desc").val(),
         "cmd": $("#amod_cmd").val(),
-        "su": $('#amod_su').prop("checked")
+        "su": $('#amod_su').prop("checked"),
+        "rr": $('#amod_rr').prop("checked")
     });
 }
 
@@ -208,5 +209,9 @@ function initializePage() {
 
     $('#amod_su_label').click(() => {
         $('#amod_su').click();
+    });
+
+    $('#amod_rr_label').click(() => {
+        $('#amod_rr').click();
     });
 }

--- a/graphenex/core/web/templates/index.html
+++ b/graphenex/core/web/templates/index.html
@@ -50,7 +50,7 @@
                             <li id="proc"><b>Processor: </b><span class="text-muted">{{ general_info.processor }}</span>
                             </li>
                         </ul>
-                        <!-- This button only visible mobile and it will open system block -->
+                        <!-- This button only visible mobile, and it will open system block -->
                         <button class="btn btn-block d-lg-none opensystembtn" style="border-width: 0; margin-top: 1%;"
                             data-toggle="collapse" data-target="#systemdiv" aria-expanded="false"
                             aria-controls="systemdiv"><i class="fas fa-chevron-down" style="font-size: 24px"></i></button>
@@ -186,6 +186,17 @@
                                 </div>
                                 <div class="form-control" id="amod_su_label"><span style="color:#D8D8D8;">
                                         Requires Superuser Privileges</span></div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="input-group">
+                                <div class="input-group-prepend">
+                                    <div class="input-group-text">
+                                        <input type="checkbox" id="amod_rr">
+                                    </div>
+                                </div>
+                                <div class="form-control" id="amod_rr_label"><span style="color:#D8D8D8;">
+                                        Requires Restart</span></div>
                             </div>
                         </div>
                     </div>

--- a/graphenex/core/web/views.py
+++ b/graphenex/core/web/views.py
@@ -131,7 +131,6 @@ def hardening_exec(data):
                     current_namespace + "/" + data)
         hrd = module_dict[current_namespace][data]
         out = hrd.execute_command()
-        print(out)
         emit(data + "_log", {"msg": out, "state": "output"})
         success_msg = "Hardening command executed successfully."
         emit('log_message', {

--- a/graphenex/core/web/views.py
+++ b/graphenex/core/web/views.py
@@ -199,6 +199,7 @@ def add_module(mod):
             "desc": mod['desc'],
             "command": mod['cmd'],
             "require_superuser": str(mod['su']).capitalize(),
+            "require_restart": str(mod['rr']).capitalize(),
             "target_os": "win" if check_os() else "linux"
         }
         # Append to json data

--- a/graphenex/modules.json
+++ b/graphenex/modules.json
@@ -1,586 +1,667 @@
 {
-  "firewall": [
-    {
-      "name": "Disable_File_Sharing",
-      "desc": "Disable File and Printer Sharing.",
-      "command": "netsh advfirewall firewall set rule group=\"File and Printer Sharing\" new enable=No",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disable_RDP",
-      "desc": "Disable Remote Desktop Protocol",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\" /v fDenyTSConnections /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "RDP_Max_Security",
-      "desc": "Maximizes the security of a Remote Desktop Connection",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp\" /v MinEncryptionLevel /t REG_DWORD /d 4 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Enable_Firewall",
-      "desc": "Enable firewall on all profiles",
-      "command": "netsh advfirewall set allprofiles state on",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Remove_Enable_LMhosts",
-      "desc": "Remove Enable LMhosts lookup",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Services\\NetBT\\Parameters\\EnableLMHosts\" /v MinEncryptionLevel /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Block_All_Ports",
-      "desc": "Block all incoming connections",
-      "command": "netsh advfirewall set allprofiles firewallpolicy blockinboundalways,allowoutbound",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disable_ICMP_IPV4",
-      "desc": "Disable the ICMP (IPV4) requests",
-      "command": "netsh advfirewall firewall add rule name='ICMP Allow incoming V4 echo request' protocol=icmpv4:8,any dir=in action=allow",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disable_ICMP_IPV6",
-      "desc": "Disable the ICMP (IPV6) requests",
-      "command": "netsh advfirewall firewall add rule name='ICMP Allow incoming V6 echo request' protocol=icmpv6:8,any dir=in action=allow",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disable_Sending_Pass_SMB",
-      "desc": "Some non-Microsoft SMB servers only support unencrypted (plain text) password authentication. Disable sending plain text passwords across the network, when authenticating to an SMB server, for increasing the overall security of the environment",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Services\\NetBT\\Parameters\" /v EnablePlainTextPassword /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Restrict_Shares_Access",
-      "desc": "Network shares that can be accessed anonymously will not be allowed",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters\" /v NullSessionShares /t REG_SZ /d (Blank) /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Allow_Only_LMA",
-      "desc": "The Kerberos v5 authentication protocol is the default for authentication for domains. NTLM which is less secure, is retained in later Windows versions for compatibility with standalone systems as well as applications that may still use it. Earlier versions of the LM/NTLM protocol are particularly vulnerable to attack and must be prevented.",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v LmCompatibilityLevel /t REG_DWORD /d 5 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    }
-  ],
-  "user": [
-    {
-      "name": "Disable_NULL_Session",
-      "desc": "Disable NTLM sessions that are allowed to fall back to Null (unauthenticated) sessions for preventing unauthorized access",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\\MSV1_0\" /v allownullsessionfallback /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disable_The_Guest_Account",
-      "desc": "Disable the guest accounts for preventing temporary login on a Windows system without requiring to provide credentials/password",
-      "command": "net user guest /active:no",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Restrict_Permission_Anon_User",
-      "desc": "Restrict the permissions of anonymous users",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v EveryoneIncludesAnonymous /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Require_Keys_For_Login",
-      "desc": "Enable the Ctrl+Alt+Del keys to login",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\" /v DisableCAD  /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Disallow_Anon_Enum_Of_SAM",
-      "desc": "Disallow anonymous logon users (null session connections) to list all account names and enumerate all shared resources",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\" /v NtfsDisableLastAccessUpdate  /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Prevent_Anon_SAM_Accounts",
-      "desc": "Disallow anonymous logon users (null session connections) to list all account names for preventing a list of potential points to attack the system.",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\" /v RestrictAnonymousSAM  /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Prevent_Group_Policy_Refresh",
-      "desc": "Set Group Policy settings not to be refreshed while a user is currently logged on",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\system\" /v DisableBkGndGroupPolicy  /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Config_Classic_Security_Model",
-      "desc": "Protect the local accounts with the classic model",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Lsa\" /v ForceGuest  /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Auto_Logout",
-      "desc": "Configure system to automatically log out users who are inactive for 15 minutes. Additionally users will be unable to modify their command history files.",
-      "command": "echo \"readonly TMOUT=900\" >> /etc/profile.d/idle-users.sh&& echo \"readonly HISTFILE\" >> /etc/profile.d/idle-users.sh&& chmod +x /etc/profile.d/idle-users.sh",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Enable_Password_Control",
-      "desc": "Enable the maximum number of days that the password applies to the root user",
-      "command": "chage -M 20 root",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_File_Permissions",
-      "desc": "Restrict GRUB configuration files & directories to root, preventing regular users from accessing or modifying them",
-      "command": "chown root:root /etc/grub.conf && chown -R root:root /etc/grub.d && chmod og-rwx /etc/grub.conf && chmod og-rwx /etc/grub.conf && chmod -R og-rwx /etc/grub.d",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_Home_Dir_Permission",
-      "desc": "The default setting allows every user on the system to access the home directory. If there's a guest account, it can also read all the data from the home directory",
-      "command": "chmod 0700 /home/$USER",
-      "require_superuser": "False",
-      "target_os": "linux"
-    }
-  ],
-  "network": [
-    {
-      "name": "Disable_Lan_Hash_Value",
-      "desc": "Disable storing the hash of the password in the LAN Manager",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\" /v NoLMHash  /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Network_Digitally_Sign_Communications",
-      "desc": "Set the SMB client for only communicating with an SMB server that performs SMB packet signing",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters\" /v RequireSecuritySignature  /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Prevent_Printing_Over_Http",
-      "desc": "Configure the system to the prevent printing over HTTP",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Printers\" /v DisableHTTPPrinting /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Enable_Cookie_Protection",
-      "desc": "Enable TCP SYN cookie protection",
-      "command": "echo \"net.ipv4.tcp_syncookies = 1\" > /etc/sysctl.d/50-net-stack.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Disable_IP_Source_Routing",
-      "desc": "Disable IP source routing",
-      "command": "echo \"net.ipv4.conf.all.accept_source_route = 0\" > /etc/sysctl.d/50-net-stack.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Disable_Redirect_Acceptance",
-      "desc": "Disable ICMP redirect acceptance",
-      "command": "echo \"net.ipv4.conf.all.accept_redirects = 0\" > /etc/sysctl.d/50-net-stack.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Ignore_ICMP",
-      "desc": "Enable ignoring the ICMP requests",
-      "command": "echo \"net.ipv4.icmp_echo_ignore_all = 1\" > /etc/sysctl.d/50-net-stack.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Ignore_Broadcast",
-      "desc": "Enable ignoring the broadcasts requests",
-      "command": "echo \"net.ipv4.icmp_echo_ignore_broadcasts = 1\" > /etc/sysctl.d/50-net-stack.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Force_SYN",
-      "desc": "Make sure new incoming TCP connections are SYN packets",
-      "command": "iptables -A INPUT -p tcp ! --syn -m state --state NEW -j DROP",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Fragment_Drop",
-      "desc": "Drop the incoming packets with fragments",
-      "command": "iptables -A INPUT -f -j DROP",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "XMAS_Drop",
-      "desc": "Drop the incoming malformed XMAS packets",
-      "command": "iptables -A INPUT -p tcp --tcp-flags ALL ALL -j DROP",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Drop_Null",
-      "desc": "Drop the incoming malformed NULL packets",
-      "command": "iptables -A INPUT -p tcp --tcp-flags ALL NONE -j DROP",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_Permissions_Network_Settings",
-      "desc": "Set permissions on network settings",
-      "command": "chmod 0750 /bin/ping && chmod 0750 /sbin/ifconfig",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_Permissions_Users",
-      "desc": "Set permissions of user info commands",
-      "command": "chmod 0750 /usr/bin/w && chmod 0750 /usr/bin/who",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_Permissions_System_Configuration",
-      "desc": "Set permissions of the system configuration",
-      "command": "chmod 0750 /usr/bin/locate && chmod 0750 /usr/bin/whereis",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Disable_IPv6_Systemwide",
-      "desc": "Disabling IPv6 Systemwide can reduce the attack surface of a system a lot (assuming you are not using it)",
-      "command": "echo \"net.ipv6.conf.all.disable_ipv6 = 1\" >> /etc/sysctl.conf && echo \"net.ipv6.conf.default.disable_ipv6 = 1\" >> /etc/sysctl.conf && echo \"net.ipv6.conf.lo.disable_ipv6 = 1 >> /etc/sysctl.conf\"",
-      "require_superuser": "True",
-      "target_os": "linux"
-    }
-  ],
-  "services": [
-    {
-      "name": "Prevent_Remote_Assistance",
-      "desc": "Prevent unsolicited offers of help to the system",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v fAllowUnsolicited  /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "NTFS_Update_Disable",
-      "desc": "Disable the NTFS updates for extra performance out of the disk volumes",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v RestrictAnonymous  /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Machine_Inactivity_15_Min",
-      "desc": "Set the screen saver at a maximum of 15 minutes",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\" /v InactivityTimeoutSecs  /t REG_DWORD /d 0x00000384 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "IPSec_Exemptions_Limited",
-      "desc": "Configure the Windows to limit IPSec exemptions",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\IPSEC\" /v NoDefaultExempt  /t REG_DWORD /d 3 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "WinExplorer_Heap_Corruption_Disable",
-      "desc": "Disable the heap termination on corruption",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v fAllowUnsolicited  /t REG_DWORD /d 0 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Remote_Logfiles_Generate",
-      "desc": "Generate the log files on Remote Assistance",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v LoggingEnabled /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "SubSystem_Require_Case_Insensitivity",
-      "desc": "Require the case insensitivity restrictions for preventing the access of files or commands that must be restricted",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\" /v ObCaseInsensitive /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Safe_DLL_Search_Mode",
-      "desc": "Search the %systemroot% for the DLL before searching the current directory or the rest of the path",
-      "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\" /v SafeDllSearchMode /t REG_DWORD /d 1 /f",
-      "require_superuser": "False",
-      "target_os": "win"
-    },
-    {
-      "name": "Syslog_Service",
-      "desc": "Ensure syslog service is enabled and running",
-      "command": "systemctl enable rsyslog && systemctl start rsyslog",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Set_Permissions_Preload_File",
-      "desc": "Set permissions of the sysctl preload/configuration file",
-      "command": "chmod 0700 /etc/sysctl.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    }
-  ],
-  "kernel": [
-    {
-      "name": "Logs_Restrict_Access",
-      "desc": "Restrict access to kernel logs",
-      "command": "echo \"kernel.dmesg_restrict = 1\" > /etc/sysctl.d/50-dmesg-restrict.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Pointers_Restrict_Access",
-      "desc": "Restrict access to kernel pointers",
-      "command": "echo \"kernel.kptr_restrict = 1\" > /etc/sysctl.d/50-kptr-restrict.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "ExecShield_Protection",
-      "desc": "Enable the ExecShield protection",
-      "command": "echo \"kernel.exec-shield = 2\" > /etc/sysctl.d/50-exec-shield.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Randomise_Memory",
-      "desc": "Randomise the memory space",
-      "command": "echo \"kernel.randomize_va_space=2\" > /etc/sysctl.d/50-rand-va-space.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    }
-  ],
-  "filesystem": [
-    {
-      "name": "Link_Protection",
-      "desc": "Enable hard/soft link protection",
-      "command": "echo \"fs.protected_hardlinks = 1\" > /etc/sysctl.d/50-fs-hardening.conf && echo \"fs.protected_symlinks = 1\" >> /etc/sysctl.d/50-fs-hardening.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "Disable_Uncommon_FS",
-      "desc": "Disable uncommon filesystems",
-      "command": "echo \"install cramfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install freevxfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install jffs2 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install hfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install hfsplus /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install squashfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install udf /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install fat /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install vfat /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install nfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install nfsv3 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install gfs2 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf",
-      "require_superuser": "True",
-      "target_os": "linux"
-    }
-  ],
-  "other": [
-    {
-      "name": "SSH_Disable_Root",
-      "desc": "Disable the option to login directly as root via SSH, use sudo instead",
-      "command": "echo \"PermitRootLogin no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Password_Login",
-      "desc": "Disable SSH authentication using passwords and force keys instead",
-      "command": "echo \"ChallengeResponseAuthentication no\" >> /etc/ssh/sshd_config && echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Empty_Passwords",
-      "desc": "Disable empty passwords on SSH Authentication",
-      "command": "echo \"PermitEmptyPasswords no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Change_Default_Port",
-      "desc": "Change default SSH port",
-      "command": "echo \"Port 4567\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Protocol_1",
-      "desc": "Some older linux distributions might still have Protocol 1 available. It has known vulnerabilities, and shouldn't be used anymore",
-      "command": "echo \"Protocol 2\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_X11_Forwarding",
-      "desc": "The X11 protocol is not security oriented. It should be disabled if not needed",
-      "command": "echo \"X11Forwarding no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_IPv6",
-      "desc": "Turn off IPv6 for SSH",
-      "command": "echo \"AddressFamily inet\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_GSSAPI_Auth",
-      "desc": "Disable GSSAPI authentication",
-      "command": "echo \"GSSAPIAuthentication no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Kerberos_Auth",
-      "desc": "Disable Kerberos authentication",
-      "command": "echo \"KerberosAuthentication no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Banner",
-      "desc": "Disable SSH verbose banner that shows various information about OS, such as version",
-      "command": "echo \"DebianBanner no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Max_Auth_Tries",
-      "desc": "Limit the number of SSH login attempts such that after a number of failed attempts, the connection drops",
-      "command": "echo \"MaxAuthTries 3\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Login_Grace_Time",
-      "desc": "Reduce the amount of time (in seconds) a user has to complete authentication after connecting to SSH server",
-      "command": "echo \"LoginGraceTime 30\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Agent_Forwarding",
-      "desc": "Disable Agent forwarding",
-      "command": "echo \"AllowAgentForwarding no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Tcp_Forwarding",
-      "desc": "Disable TCP forwarding",
-      "command": "echo \"AllowTcpForwarding no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Tunnel",
-      "desc": "Disable device forwarding",
-      "command": "echo \"PermitTunnel no\" >> /etc/ssh/sshd_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_X11_Forwarding",
-      "desc": "Disable X11 display forwarding",
-      "command": "echo \"ForwardX11 no\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_Tunnel",
-      "desc": "Disable tunneling",
-      "command": "echo \"Tunnel no\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_Agent_Forwarding",
-      "desc": "Disable agent forwarding",
-      "command": "echo \"ForwardAgent no\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_GSSAPI_Auth",
-      "desc": "Disable GSSAPI authentication",
-      "command": "echo \"GSSAPIAuthentication no\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_HostBased_Auth",
-      "desc": "Disable host based authentication",
-      "command": "echo \"HostbasedAuthentication no\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Disable_Client_Legacy_Ciphers",
-      "desc": "Disable legacy 'Arcfour ciphers'",
-      "command": "echo \"Ciphers -arcfour*,-*cbc\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    },
-    {
-      "name": "SSH_Client_Key_Warn",
-      "desc": "Get warning if key / fingerprint of remote server has changed",
-      "command": "echo \"StrictHostKeyChecking ask\" >> /etc/ssh/ssh_config",
-      "require_superuser": "True",
-      "target_os": "linux"
-    }
-  ],
-  "presets": [
-    {
-      "name": "Kernel_Access_Restriction",
-      "modules": [
-        "kernel/Logs_Restrict_Access",
-        "kernel/Pointers_Restrict_Access"
-      ],
-      "target_os": "linux"
-    },
-    {
-      "name": "Linux_Network_Hardening",
-      "modules": ["network/All"],
-      "target_os": "linux"
-    },
-    {
-      "name": "Windows_Network_Hardening",
-      "modules": ["network/All"],
-      "target_os": "win"
-    },
-    {
-      "name": "Windows_Firewall_Rules",
-      "modules": [
-        "firewall/Enable_Firewall",
-        "firewall/Block_All_Ports",
-        "firewall/Disable_File_Sharing",
-        "firewall/Disable_ICMP_IPV4",
-        "firewall/Disable_ICMP_IPV6"
-      ],
-      "target_os": "win"
-    }
-  ]
+    "firewall": [
+        {
+            "name": "Disable_File_Sharing",
+            "desc": "Disable File and Printer Sharing.",
+            "command": "netsh advfirewall firewall set rule group=\"File and Printer Sharing\" new enable=No",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disable_RDP",
+            "desc": "Disable Remote Desktop Protocol",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\" /v fDenyTSConnections /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "RDP_Max_Security",
+            "desc": "Maximizes the security of a Remote Desktop Connection",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp\" /v MinEncryptionLevel /t REG_DWORD /d 4 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Enable_Firewall",
+            "desc": "Enable firewall on all profiles",
+            "command": "netsh advfirewall set allprofiles state on",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Remove_Enable_LMhosts",
+            "desc": "Remove Enable LMhosts lookup",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Services\\NetBT\\Parameters\\EnableLMHosts\" /v MinEncryptionLevel /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Block_All_Ports",
+            "desc": "Block all incoming connections",
+            "command": "netsh advfirewall set allprofiles firewallpolicy blockinboundalways,allowoutbound",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disable_ICMP_IPV4",
+            "desc": "Disable the ICMP (IPV4) requests",
+            "command": "netsh advfirewall firewall add rule name='ICMP Allow incoming V4 echo request' protocol=icmpv4:8,any dir=in action=allow",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disable_ICMP_IPV6",
+            "desc": "Disable the ICMP (IPV6) requests",
+            "command": "netsh advfirewall firewall add rule name='ICMP Allow incoming V6 echo request' protocol=icmpv6:8,any dir=in action=allow",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disable_Sending_Pass_SMB",
+            "desc": "Some non-Microsoft SMB servers only support unencrypted (plain text) password authentication. Disable sending plain text passwords across the network, when authenticating to an SMB server, for increasing the overall security of the environment",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Services\\NetBT\\Parameters\" /v EnablePlainTextPassword /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Restrict_Shares_Access",
+            "desc": "Network shares that can be accessed anonymously will not be allowed",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters\" /v NullSessionShares /t REG_SZ /d (Blank) /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Allow_Only_LMA",
+            "desc": "The Kerberos v5 authentication protocol is the default for authentication for domains. NTLM which is less secure, is retained in later Windows versions for compatibility with standalone systems as well as applications that may still use it. Earlier versions of the LM/NTLM protocol are particularly vulnerable to attack and must be prevented.",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v LmCompatibilityLevel /t REG_DWORD /d 5 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        }
+    ],
+    "user": [
+        {
+            "name": "Disable_NULL_Session",
+            "desc": "Disable NTLM sessions that are allowed to fall back to Null (unauthenticated) sessions for preventing unauthorized access",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\\MSV1_0\" /v allownullsessionfallback /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disable_The_Guest_Account",
+            "desc": "Disable the guest accounts for preventing temporary login on a Windows system without requiring to provide credentials/password",
+            "command": "net user guest /active:no",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Restrict_Permission_Anon_User",
+            "desc": "Restrict the permissions of anonymous users",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v EveryoneIncludesAnonymous /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Require_Keys_For_Login",
+            "desc": "Enable the Ctrl+Alt+Del keys to login",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\" /v DisableCAD  /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Disallow_Anon_Enum_Of_SAM",
+            "desc": "Disallow anonymous logon users (null session connections) to list all account names and enumerate all shared resources",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\FileSystem\" /v NtfsDisableLastAccessUpdate  /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Prevent_Anon_SAM_Accounts",
+            "desc": "Disallow anonymous logon users (null session connections) to list all account names for preventing a list of potential points to attack the system.",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\" /v RestrictAnonymousSAM  /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Prevent_Group_Policy_Refresh",
+            "desc": "Set Group Policy settings not to be refreshed while a user is currently logged on",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\system\" /v DisableBkGndGroupPolicy  /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Config_Classic_Security_Model",
+            "desc": "Protect the local accounts with the classic model",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Lsa\" /v ForceGuest  /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Auto_Logout",
+            "desc": "Configure system to automatically log out users who are inactive for 15 minutes. Additionally users will be unable to modify their command history files.",
+            "command": "echo \"readonly TMOUT=900\" >> /etc/profile.d/idle-users.sh&& echo \"readonly HISTFILE\" >> /etc/profile.d/idle-users.sh&& chmod +x /etc/profile.d/idle-users.sh",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Enable_Password_Control",
+            "desc": "Enable the maximum number of days that the password applies to the root user",
+            "command": "chage -M 20 root",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_File_Permissions",
+            "desc": "Restrict GRUB configuration files & directories to root, preventing regular users from accessing or modifying them",
+            "command": "chown root:root /etc/grub.conf && chown -R root:root /etc/grub.d && chmod og-rwx /etc/grub.conf && chmod og-rwx /etc/grub.conf && chmod -R og-rwx /etc/grub.d",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_Home_Dir_Permission",
+            "desc": "The default setting allows every user on the system to access the home directory. If there's a guest account, it can also read all the data from the home directory",
+            "command": "chmod 0700 /home/$USER",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "linux"
+        }
+    ],
+    "network": [
+        {
+            "name": "Disable_Lan_Hash_Value",
+            "desc": "Disable storing the hash of the password in the LAN Manager",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\" /v NoLMHash  /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Network_Digitally_Sign_Communications",
+            "desc": "Set the SMB client for only communicating with an SMB server that performs SMB packet signing",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters\" /v RequireSecuritySignature  /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Prevent_Printing_Over_Http",
+            "desc": "Configure the system to the prevent printing over HTTP",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Printers\" /v DisableHTTPPrinting /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Enable_Cookie_Protection",
+            "desc": "Enable TCP SYN cookie protection",
+            "command": "echo \"net.ipv4.tcp_syncookies = 1\" > /etc/sysctl.d/50-net-stack.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Disable_IP_Source_Routing",
+            "desc": "Disable IP source routing",
+            "command": "echo \"net.ipv4.conf.all.accept_source_route = 0\" > /etc/sysctl.d/50-net-stack.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Disable_Redirect_Acceptance",
+            "desc": "Disable ICMP redirect acceptance",
+            "command": "echo \"net.ipv4.conf.all.accept_redirects = 0\" > /etc/sysctl.d/50-net-stack.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Ignore_ICMP",
+            "desc": "Enable ignoring the ICMP requests",
+            "command": "echo \"net.ipv4.icmp_echo_ignore_all = 1\" > /etc/sysctl.d/50-net-stack.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Ignore_Broadcast",
+            "desc": "Enable ignoring the broadcasts requests",
+            "command": "echo \"net.ipv4.icmp_echo_ignore_broadcasts = 1\" > /etc/sysctl.d/50-net-stack.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Force_SYN",
+            "desc": "Make sure new incoming TCP connections are SYN packets",
+            "command": "iptables -A INPUT -p tcp ! --syn -m state --state NEW -j DROP",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Fragment_Drop",
+            "desc": "Drop the incoming packets with fragments",
+            "command": "iptables -A INPUT -f -j DROP",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "XMAS_Drop",
+            "desc": "Drop the incoming malformed XMAS packets",
+            "command": "iptables -A INPUT -p tcp --tcp-flags ALL ALL -j DROP",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Drop_Null",
+            "desc": "Drop the incoming malformed NULL packets",
+            "command": "iptables -A INPUT -p tcp --tcp-flags ALL NONE -j DROP",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_Permissions_Network_Settings",
+            "desc": "Set permissions on network settings",
+            "command": "chmod 0750 /bin/ping && chmod 0750 /sbin/ifconfig",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_Permissions_Users",
+            "desc": "Set permissions of user info commands",
+            "command": "chmod 0750 /usr/bin/w && chmod 0750 /usr/bin/who",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_Permissions_System_Configuration",
+            "desc": "Set permissions of the system configuration",
+            "command": "chmod 0750 /usr/bin/locate && chmod 0750 /usr/bin/whereis",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Disable_IPv6_Systemwide",
+            "desc": "Disabling IPv6 Systemwide can reduce the attack surface of a system a lot (assuming you are not using it)",
+            "command": "echo \"net.ipv6.conf.all.disable_ipv6 = 1\" >> /etc/sysctl.conf && echo \"net.ipv6.conf.default.disable_ipv6 = 1\" >> /etc/sysctl.conf && echo \"net.ipv6.conf.lo.disable_ipv6 = 1 >> /etc/sysctl.conf\"",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        }
+    ],
+    "services": [
+        {
+            "name": "Prevent_Remote_Assistance",
+            "desc": "Prevent unsolicited offers of help to the system",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v fAllowUnsolicited  /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "NTFS_Update_Disable",
+            "desc": "Disable the NTFS updates for extra performance out of the disk volumes",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Control\\Lsa\" /v RestrictAnonymous  /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Machine_Inactivity_15_Min",
+            "desc": "Set the screen saver at a maximum of 15 minutes",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\" /v InactivityTimeoutSecs  /t REG_DWORD /d 0x00000384 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "IPSec_Exemptions_Limited",
+            "desc": "Configure the Windows to limit IPSec exemptions",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Services\\IPSEC\" /v NoDefaultExempt  /t REG_DWORD /d 3 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "WinExplorer_Heap_Corruption_Disable",
+            "desc": "Disable the heap termination on corruption",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v fAllowUnsolicited  /t REG_DWORD /d 0 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Remote_Logfiles_Generate",
+            "desc": "Generate the log files on Remote Assistance",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\" /v LoggingEnabled /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "SubSystem_Require_Case_Insensitivity",
+            "desc": "Require the case insensitivity restrictions for preventing the access of files or commands that must be restricted",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\" /v ObCaseInsensitive /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Safe_DLL_Search_Mode",
+            "desc": "Search the %systemroot% for the DLL before searching the current directory or the rest of the path",
+            "command": "reg add \"HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\" /v SafeDllSearchMode /t REG_DWORD /d 1 /f",
+            "require_superuser": "False",
+            "require_restart": "False",
+            "target_os": "win"
+        },
+        {
+            "name": "Syslog_Service",
+            "desc": "Ensure syslog service is enabled and running",
+            "command": "systemctl enable rsyslog && systemctl start rsyslog",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Set_Permissions_Preload_File",
+            "desc": "Set permissions of the sysctl preload/configuration file",
+            "command": "chmod 0700 /etc/sysctl.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        }
+    ],
+    "kernel": [
+        {
+            "name": "Logs_Restrict_Access",
+            "desc": "Restrict access to kernel logs",
+            "command": "echo \"kernel.dmesg_restrict = 1\" > /etc/sysctl.d/50-dmesg-restrict.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Pointers_Restrict_Access",
+            "desc": "Restrict access to kernel pointers",
+            "command": "echo \"kernel.kptr_restrict = 1\" > /etc/sysctl.d/50-kptr-restrict.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "ExecShield_Protection",
+            "desc": "Enable the ExecShield protection",
+            "command": "echo \"kernel.exec-shield = 2\" > /etc/sysctl.d/50-exec-shield.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Randomise_Memory",
+            "desc": "Randomise the memory space",
+            "command": "echo \"kernel.randomize_va_space=2\" > /etc/sysctl.d/50-rand-va-space.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        }
+    ],
+    "filesystem": [
+        {
+            "name": "Link_Protection",
+            "desc": "Enable hard/soft link protection",
+            "command": "echo \"fs.protected_hardlinks = 1\" > /etc/sysctl.d/50-fs-hardening.conf && echo \"fs.protected_symlinks = 1\" >> /etc/sysctl.d/50-fs-hardening.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        },
+        {
+            "name": "Disable_Uncommon_FS",
+            "desc": "Disable uncommon filesystems",
+            "command": "echo \"install cramfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install freevxfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install jffs2 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install hfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install hfsplus /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install squashfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install udf /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install fat /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install vfat /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install nfs /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install nfsv3 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf && echo \"install gfs2 /bin/false\" >> /etc/modprobe.d/uncommon-fs.conf",
+            "require_superuser": "True",
+            "require_restart": "False",
+            "target_os": "linux"
+        }
+    ],
+    "other": [
+        {
+            "name": "SSH_Disable_Root",
+            "desc": "Disable the option to login directly as root via SSH, use sudo instead",
+            "command": "echo \"PermitRootLogin no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Password_Login",
+            "desc": "Disable SSH authentication using passwords and force keys instead",
+            "command": "echo \"ChallengeResponseAuthentication no\" >> /etc/ssh/sshd_config && echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Empty_Passwords",
+            "desc": "Disable empty passwords on SSH Authentication",
+            "command": "echo \"PermitEmptyPasswords no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Change_Default_Port",
+            "desc": "Change default SSH port",
+            "command": "echo \"Port 4567\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Protocol_1",
+            "desc": "Some older linux distributions might still have Protocol 1 available. It has known vulnerabilities, and shouldn't be used anymore",
+            "command": "echo \"Protocol 2\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_X11_Forwarding",
+            "desc": "The X11 protocol is not security oriented. It should be disabled if not needed",
+            "command": "echo \"X11Forwarding no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_IPv6",
+            "desc": "Turn off IPv6 for SSH",
+            "command": "echo \"AddressFamily inet\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_GSSAPI_Auth",
+            "desc": "Disable GSSAPI authentication",
+            "command": "echo \"GSSAPIAuthentication no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Kerberos_Auth",
+            "desc": "Disable Kerberos authentication",
+            "command": "echo \"KerberosAuthentication no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Banner",
+            "desc": "Disable SSH verbose banner that shows various information about OS, such as version",
+            "command": "echo \"DebianBanner no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Max_Auth_Tries",
+            "desc": "Limit the number of SSH login attempts such that after a number of failed attempts, the connection drops",
+            "command": "echo \"MaxAuthTries 3\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Login_Grace_Time",
+            "desc": "Reduce the amount of time (in seconds) a user has to complete authentication after connecting to SSH server",
+            "command": "echo \"LoginGraceTime 30\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Agent_Forwarding",
+            "desc": "Disable Agent forwarding",
+            "command": "echo \"AllowAgentForwarding no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Tcp_Forwarding",
+            "desc": "Disable TCP forwarding",
+            "command": "echo \"AllowTcpForwarding no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Tunnel",
+            "desc": "Disable device forwarding",
+            "command": "echo \"PermitTunnel no\" >> /etc/ssh/sshd_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_X11_Forwarding",
+            "desc": "Disable X11 display forwarding",
+            "command": "echo \"ForwardX11 no\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_Tunnel",
+            "desc": "Disable tunneling",
+            "command": "echo \"Tunnel no\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_Agent_Forwarding",
+            "desc": "Disable agent forwarding",
+            "command": "echo \"ForwardAgent no\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_GSSAPI_Auth",
+            "desc": "Disable GSSAPI authentication",
+            "command": "echo \"GSSAPIAuthentication no\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_HostBased_Auth",
+            "desc": "Disable host based authentication",
+            "command": "echo \"HostbasedAuthentication no\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Disable_Client_Legacy_Ciphers",
+            "desc": "Disable legacy 'Arcfour ciphers'",
+            "command": "echo \"Ciphers -arcfour*,-*cbc\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        },
+        {
+            "name": "SSH_Client_Key_Warn",
+            "desc": "Get warning if key / fingerprint of remote server has changed",
+            "command": "echo \"StrictHostKeyChecking ask\" >> /etc/ssh/ssh_config",
+            "require_superuser": "True",
+            "require_restart": "True",
+            "target_os": "linux"
+        }
+    ],
+    "presets": [
+        {
+            "name": "Kernel_Access_Restriction",
+            "modules": [
+                "kernel/Logs_Restrict_Access",
+                "kernel/Pointers_Restrict_Access"
+            ],
+            "target_os": "linux"
+        },
+        {
+            "name": "Linux_Network_Hardening",
+            "modules": [
+                "network/All"
+            ],
+            "target_os": "linux"
+        },
+        {
+            "name": "Windows_Network_Hardening",
+            "modules": [
+                "network/All"
+            ],
+            "target_os": "win"
+        },
+        {
+            "name": "Windows_Firewall_Rules",
+            "modules": [
+                "firewall/Enable_Firewall",
+                "firewall/Block_All_Ports",
+                "firewall/Disable_File_Sharing",
+                "firewall/Disable_ICMP_IPV4",
+                "firewall/Disable_ICMP_IPV6"
+            ],
+            "target_os": "win"
+        }
+    ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added 'require_restart' key to modules.json.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #131.
Currently we can execute a hardening module, but how do we really know that the changes have been applied? We don't.
The solution is to add the 'require_restart' field, which will give a hint to the user.

Yes, there are no 'restart' commands provided, because if the user is hardening (for example) SSHD config, than he should know that all he has to do is google: 'restart sshd config'

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It works correctly on both Web UI and CLI.
CLI tested:
- add new module
- edit module
- remove module
- run module

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
