### PR TITLE
chore: remove redundant __import__

### DIFF
--- a/graphenex/core/utils/helpers.py
+++ b/graphenex/core/utils/helpers.py
@@ -75,7 +75,7 @@ def check_os():
     [1] -> Windows
     [0] -> Linux (else)
     """
-    return 1 if __import__('os').name == 'nt' else 0
+    return 1 if os.name == 'nt' else 0
 
 
 def check_privileges():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There's no need to use __import__('os').name as we already have imported os - therefore we can just use os.name

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Less cluttered code + better readability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran gX as CLI + Web UI.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
