### PR TITLE
fix: remove CAN_USE_BOLD_FONT attribute

### DIFF
--- a/graphenex/core/utils/logcl.py
+++ b/graphenex/core/utils/logcl.py
@@ -45,7 +45,7 @@ class GraphenexLogger(logging.Logger):
         FIELD_STYLES = dict(
             asctime=dict(color='green'),
             hostname=dict(color='magenta'),
-            levelname=dict(color='cyan', bold=coloredlogs.CAN_USE_BOLD_FONT),
+            levelname=dict(color='cyan'),
             filename=dict(color='magenta'),
             name=dict(color='blue'),
             threadName=dict(color='green')


### PR DESCRIPTION
On [v14.0 coloredlogs removed CAN_USE_BOLD_FONT](https://github.com/xolox/python-coloredlogs/commit/044402534c2dd02ff340df2950e485ce4999386c), now bold is always `True`. This fixes `AttributeError` (pic):

![Screenshot from 2024-05-26 22-53-45](https://github.com/grapheneX/grapheneX/assets/138708600/d2779061-a8f5-44f9-9f3a-538f97a8da05)
