### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,14 @@
+# GitHub files
+LICENSE
+MANIFEST.in
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+
 # Git files / dirs
 .git
 .gitignore
 .gitattributes
 
-# GitHub Markdown files
-*.md
-
-# Others
-LICENSE
-MANIFEST.in
+# Other
+.bumpversion.cfg
+ruff.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Git files / dirs
+.git
+.gitignore
+.gitattributes
+
+# GitHub Markdown files
+*.md
+
+# Others
+LICENSE
+MANIFEST.in

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.14-slim as base
+FROM python:3.10-slim as base
 LABEL maintainer="graphenex.project@protonmail.com"
 ENV LC_ALL=C.UTF-8
 ENV PYTHONUNBUFFERED=1 \
@@ -12,7 +12,8 @@ FROM base as builder
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
         build-essential \
-        curl
+        curl \
+    && rm -rf /var/lib/apt/lists*
 ENV PATH="$POETRY_HOME/bin:$PATH"
 RUN curl -sSL https://install.python-poetry.org | python -
 COPY . ./


### PR DESCRIPTION
- add `.dockerignore` to ignore unnecessary files / dirs to decrease docker image size (Wanted to ignore all `*.md` files, but docker fails to run for some reason without `README.md`
- pin python image to `3.10` this actually keeps us at the most up-2-date image with security updates (you learn something new everyday)
- remove apt cache to reduce docker image size

Tested by building and running the tag.